### PR TITLE
修復 prepare_data.py 批次處理導致資料重複的問題

### DIFF
--- a/finetuning/prepare_data.py
+++ b/finetuning/prepare_data.py
@@ -56,7 +56,9 @@ def main():
         for code, line in zip(enc_res.audio_codes, batch_lines):
             line['audio_codes'] = code.cpu().tolist()
             final_lines.append(line)
-
+        batch_lines = []
+        batch_audios = []
+        
     final_lines = [json.dumps(line, ensure_ascii=False) for line in final_lines]
 
     with open(args.output_jsonl, 'w') as f:


### PR DESCRIPTION
## 問題描述 (Problem)

在 `finetuning/prepare_data.py` 中，批次處理音訊資料時會產生大量重複的資料到 `train_with_codes.jsonl`。

## 根本原因 (Root Cause)

程式碼在處理批次資料時存在邏輯錯誤：

1. 當 `batch_lines` 累積到 32 筆時，會進行批次編碼並加入 `final_lines`
2. 但處理完後**沒有清空** `batch_lines` 和 `batch_audios`
3. 這些已處理的資料會繼續累積，並在最後的收尾邏輯（第 60-64 行）中被**再次處理**
4. 導致除了最後一批以外的所有資料都被重複寫入

## 修復方案 (Solution)

在批次處理完成後，清空 `batch_lines` 和 `batch_audios`：

```
if len(batch_lines) >= BATCH_INFER_NUM:
    enc_res = tokenizer_12hz.encode(batch_audios)
    for code, line in zip(enc_res.audio_codes, batch_lines):
        line['audio_codes'] = code.cpu().tolist()
        final_lines.append(line)
    batch_lines = []        # 新增：清空批次緩衝區
    batch_audios = []       # 新增：清空批次緩衝區
```
