### PR TITLE
fix: star history image url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1355,7 +1355,7 @@ If you find our paper and code useful in your research, please consider giving a
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=QwenLM/Qwen-TTS&type=Date)](https://star-history.com/#QwenLM/Qwen-TTS&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=QwenLM/Qwen3-TTS&type=Date)](https://star-history.com/#QwenLM/Qwen3-TTS&Date)
 
 
 <br>


### PR DESCRIPTION
to show correct star history

<img width="3152" height="2306" alt="star-history-2026124" src="https://github.com/user-attachments/assets/a30cbff4-01c5-490c-a97a-1d8f9687d1ab" />
