### PR TITLE
Fix PyTorch CUDA installation issue - Remove torchaudio from dependen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,26 @@ conda create -n qwen3-tts python=3.12 -y
 conda activate qwen3-tts
 ```
 
-then run:
+**Important:** Before installing `qwen-tts`, you need to install PyTorch with CUDA support. The `qwen-tts` package does not include PyTorch in its dependencies to avoid installing the CPU-only version from PyPI. This way, if you install PyTorch with CUDA first, it won't be reinstalled when installing `qwen-tts`, saving bandwidth and avoiding conflicts.
 
+Install PyTorch with CUDA support first:
+
+For CUDA 12.1:
+```bash
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+```
+
+For CUDA 11.8:
+```bash
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+```
+
+For CPU-only (not recommended for inference):
+```bash
+pip install torch torchvision torchaudio
+```
+
+Then install qwen-tts (PyTorch will not be reinstalled if already present):
 ```bash
 pip install -U qwen-tts
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "accelerate==1.12.0",
   "gradio",
   "librosa",
-  "torchaudio",
   "soundfile",
   "sox",
   "onnxruntime",


### PR DESCRIPTION
# Fix PyTorch CUDA Installation Issue

## Problem

When installing `qwen-tts` from PyPI, PyTorch was being installed without CUDA support (CPU-only version). This happened because:

1. The `pyproject.toml` included `torchaudio` as a dependency
2. When `torchaudio` is installed from PyPI, it automatically pulls in `torch` as a dependency
3. The default `torch` package on PyPI is CPU-only, which doesn't support CUDA

This caused issues for users who need GPU acceleration for model inference.

## Solution

1. **Removed `torchaudio` from dependencies** in `pyproject.toml`
   - This prevents automatic installation of CPU-only PyTorch
   - Users can now install PyTorch with CUDA support manually before installing `qwen-tts`

2. **Updated README.md** with clear installation instructions
   - Added step-by-step guide for installing PyTorch with CUDA support
   - Included commands for CUDA 12.1, CUDA 11.8, and CPU-only versions
   - Clarified that PyTorch won't be reinstalled if already present, saving bandwidth

## Benefits

- ✅ Users can install PyTorch with their preferred CUDA version
- ✅ No unnecessary re-downloads (saves ~3GB bandwidth)
- ✅ Avoids dependency conflicts
- ✅ Follows best practices used by other ML projects (e.g., HuggingFace Transformers)

## Changes Made

- **pyproject.toml**: Removed `torchaudio` from dependencies list
- **README.md**: Added PyTorch CUDA installation instructions in the Environment Setup section

## Testing

To test this fix:

1. Create a fresh environment:
   ```bash
   conda create -n test-qwen python=3.12 -y
   conda activate test-qwen
   ```

2. Install PyTorch with CUDA:
   ```bash
   pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
   ```

3. Install qwen-tts:
   ```bash
   pip install -U qwen-tts
   ```

4. Verify PyTorch has CUDA support:
   ```python
   import torch
   print(torch.cuda.is_available())  # Should print True
   ```

## Related Issues

This fix addresses the issue where PyTorch was being installed without CUDA support when installing from PyPI.