### PR TITLE
Dockerfile for Demo with 1.7B Base Model

### DIFF
--- a/demo/dockerfiles/Dockerfile-1.7B-Base
+++ b/demo/dockerfiles/Dockerfile-1.7B-Base
@@ -2,7 +2,8 @@ FROM pytorch/pytorch:2.8.0-cuda12.8-cudnn9-runtime
 
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    HF_HOME=/app/models
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \


### PR DESCRIPTION
This is a Dockerfile for quickly building and running the demo interface.

Tested on Ubuntu 22.04.5 LTS with an RTX 3090.

Use it for Demo with Voice Cloning and TTS.

Usage:
```shell
docker build -t demo -f demo/dockerfiles/Dockerfile-1.7B-Base .
docker run --rm --gpus all -p 8000:8000 demo
```

Uses pytorch:2.8.0-cuda12.8-cudnn9-runtime and wheel for flash attention.
Image size aprox. 4.6 GB.