### PR TITLE
Fix wrong project.urls (Homepage/Repository) in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/Qwen/Qwen3-TTS"
-Repository = "https://github.com/Qwen/Qwen3-TTS"
+Homepage = "https://github.com/QwenLM/Qwen3-TTS"
+Repository = "https://github.com/QwenLM/Qwen3-TTS"
 
 [project.scripts]
 qwen-tts-demo = "qwen_tts.cli.demo:main"


### PR DESCRIPTION
pyproject.toml's [project.urls] currently points to https://github.com/Qwen/Qwen3-TTS, which is a 404.
Update Homepage/Repository to https://github.com/QwenLM/Qwen3-TTS.
[PyPI project links](https://pypi.org/project/qwen-tts/) are rendered from uploaded distribution metadata, so this will fix the links on PyPI after the next release is published.  ￼
