### PR TITLE
transformers>=4.57.3,<5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ license = { text = "Apache-2.0" }
 authors = [{ name = "Alibaba Qwen Team" }]
 
 dependencies = [
-  "transformers==4.57.3",
+  "transformers>=4.57.3,<5",
   "accelerate==1.12.0",
   "gradio",
   "librosa",


### PR DESCRIPTION
Related issue: https://github.com/QwenLM/Qwen3-TTS/issues/156

`qwen-tts` hard-pins `transformers==4.57.3`, preventing co-installation with `qwen-asr` despite verified compatibility.

This pull request makes the transformers dependency more flexible, allowing the installation of `qwen-tts` and `qwen-asr` in the same environment.

To confirm functionality:

```shell
pip install \
  git+https://github.com/joshuasundance-swca/Qwen3-ASR.git@transformers-pin \
  git+https://github.com/joshuasundance-swca/Qwen3-TTS.git@transformers-pin
```