### PR TITLE
Resolve each training epoch resulting in progressively faster output

### DIFF
--- a/finetuning/sft_12hz.py
+++ b/finetuning/sft_12hz.py
@@ -92,11 +92,6 @@ def train():
 
                 input_embeddings = input_text_embedding + input_codec_embedding
 
-                for i in range(1, 16):
-                    codec_i_embedding = model.talker.code_predictor.get_input_embeddings()[i - 1](codec_ids[:, :, i])
-                    codec_i_embedding = codec_i_embedding * codec_mask.unsqueeze(-1)
-                    input_embeddings = input_embeddings + codec_i_embedding
-
                 outputs = model.talker(
                     inputs_embeds=input_embeddings[:, :-1, :],
                     attention_mask=attention_mask[:, :-1],


### PR DESCRIPTION
Unsure if this part on input_embeddings was prepared for sub-talker (the non-autoregressive bit) originally, or some other reason why this might be here. Problem is, for the main autoregressive model (model.talker, which determines pacing, duration, prosody, etc. and is used for predicting codec_0_label) having it breaks causality. The AR model should be learning to look at text/codec layer 0, not including looking at layers 1-15, since these don't exist yet at actual inference time. Basically, instead of learning how to time speech based on text, it appears to be learning to time speech based on... the time speech took. End result, it's "rushing" through the generated audio, seemingly faster and faster with each training epoch performed. Remove this bit of code, and all that goes away. It doesn't even appear to have a distinct impact on loss reduction speed based on my testing with a few data sets (elise, jenny, several of my own used for other models).