### PR TITLE
fix: apply text_projection for 600M model fine-tuning

### DIFF
--- a/finetuning/sft_12hz.py
+++ b/finetuning/sft_12hz.py
@@ -86,7 +86,13 @@ def train():
                 input_text_ids = input_ids[:, :, 0]
                 input_codec_ids = input_ids[:, :, 1]
 
-                input_text_embedding = model.talker.model.text_embedding(input_text_ids) * text_embedding_mask
+                input_text_embedding = model.talker.model.text_embedding(input_text_ids)
+
+                # Apply text_projection for 0.6B model (text_hidden_size != hidden_size)
+                if hasattr(model.talker, 'text_projection'):
+                    input_text_embedding = model.talker.text_projection(input_text_embedding)
+
+                input_text_embedding = input_text_embedding * text_embedding_mask
                 input_codec_embedding = model.talker.model.codec_embedding(input_codec_ids) * codec_embedding_mask
                 input_codec_embedding[:, 6, :] = speaker_embedding
 


### PR DESCRIPTION
Fix dimension mismatch by applying text_projection when text_hidden_size != hidden_size （for 600M model）