### PR TITLE
fix: preserve speaker_encoder in checkpoints and improve sample rate error

### DIFF
--- a/finetuning/dataset.py
+++ b/finetuning/dataset.py
@@ -102,7 +102,10 @@ class TTSDataset(Dataset):
     
     @torch.inference_mode()
     def extract_mels(self, audio, sr):
-        assert sr == 24000, "Only support 24kHz audio"
+        assert sr == 24000, (
+            f"Only 24kHz audio is supported, but got {sr}Hz. "
+            f"Convert with: ffmpeg -i input.wav -ar 24000 output.wav"
+        )
         mels = mel_spectrogram(
             torch.from_numpy(audio).unsqueeze(0), 
             n_fft=1024, 

--- a/finetuning/sft_12hz.py
+++ b/finetuning/sft_12hz.py
@@ -147,10 +147,11 @@ def train():
             unwrapped_model = accelerator.unwrap_model(model)
             state_dict = {k: v.detach().to("cpu") for k, v in unwrapped_model.state_dict().items()}
 
-            drop_prefix = "speaker_encoder"
-            keys_to_drop = [k for k in state_dict.keys() if k.startswith(drop_prefix)]
-            for k in keys_to_drop:
-                del state_dict[k]
+            # NOTE: speaker_encoder weights are intentionally kept in the
+            # checkpoint so that training can be resumed without losing
+            # the encoder (which would crash on the next forward pass).
+            # The final export step can strip them if a smaller artifact
+            # is desired.
 
             weight = state_dict['talker.model.codec_embedding.weight']
             state_dict['talker.model.codec_embedding.weight'][3000] = target_speaker_embedding[0].detach().to(weight.device).to(weight.dtype)


### PR DESCRIPTION
## Problem

Two issues in the finetuning script (`sft_12hz.py` / `dataset.py`):

### 1. speaker_encoder deleted from checkpoints — resume impossible

Lines 150-153 of `sft_12hz.py` explicitly delete `speaker_encoder` weights before saving:

```python
drop_prefix = "speaker_encoder"
keys_to_drop = [k for k in state_dict.keys() if k.startswith(drop_prefix)]
for k in keys_to_drop:
    del state_dict[k]
```

When resuming from a checkpoint, `model.speaker_encoder = None` → crash on the next forward pass.

### 2. Unhelpful sample rate error message

`dataset.py:105` asserts `sr == 24000` but doesn't show the detected sample rate or suggest a fix, leaving users confused.

## Fix

1. **Remove the speaker_encoder deletion** — keep weights in checkpoints so resume works. A comment explains the rationale.
2. **Improve the assertion** to show the actual sample rate and suggest the ffmpeg conversion command.

Fixes #204