### PR TITLE
fix: preserve speaker_encoder in checkpoints to allow training resume

### DIFF
--- a/finetuning/sft_12hz.py
+++ b/finetuning/sft_12hz.py
@@ -147,10 +147,8 @@ def train():
             unwrapped_model = accelerator.unwrap_model(model)
             state_dict = {k: v.detach().to("cpu") for k, v in unwrapped_model.state_dict().items()}
 
-            drop_prefix = "speaker_encoder"
-            keys_to_drop = [k for k in state_dict.keys() if k.startswith(drop_prefix)]
-            for k in keys_to_drop:
-                del state_dict[k]
+            # NOTE: speaker_encoder weights are preserved in checkpoints to allow
+            # training resume. They can be stripped for inference-only exports.
 
             weight = state_dict['talker.model.codec_embedding.weight']
             state_dict['talker.model.codec_embedding.weight'][3000] = target_speaker_embedding[0].detach().to(weight.device).to(weight.dtype)


### PR DESCRIPTION
## Problem

In `finetuning/sft_12hz.py`, the `speaker_encoder` weights are explicitly deleted from the state dict before saving checkpoints (lines 150-153). When training is resumed from one of these checkpoints, `model.speaker_encoder` is `None`, causing a crash on the first forward pass.

Related to #204 (bug 1: "Speaker encoder is removed from checkpoints – breaks resume")

## Root Cause

```python
drop_prefix = "speaker_encoder"
keys_to_drop = [k for k in state_dict.keys() if k.startswith(drop_prefix)]
for k in keys_to_drop:
    del state_dict[k]
```

## Fix

Remove the `speaker_encoder` deletion. Checkpoints now include all model weights, allowing training to resume correctly. Users who need smaller inference-only exports can strip the speaker_encoder weights in a separate post-processing step.

## Impact

- **Checkpoint size**: Increases by the size of the speaker_encoder weights (~small relative to the full model)
- **Resume**: Now works without crashes
- **Backward compatible**: Existing code that loads checkpoints without speaker_encoder will still work (missing keys are handled by the model's load logic)