### PR TITLE
Fix label alignment bug in finetuning

### DIFF
--- a/finetuning/sft_12hz.py
+++ b/finetuning/sft_12hz.py
@@ -86,7 +86,9 @@ def train():
                 input_text_ids = input_ids[:, :, 0]
                 input_codec_ids = input_ids[:, :, 1]
 
-                input_text_embedding = model.talker.model.text_embedding(input_text_ids) * text_embedding_mask
+                input_text_embedding = self.model.talker.text_projection(
+                            self.model.talker.model.text_embedding(input_text_ids)
+                        ) * text_embedding_mask
                 input_codec_embedding = model.talker.model.codec_embedding(input_codec_ids) * codec_embedding_mask
                 input_codec_embedding[:, 6, :] = speaker_embedding
 
@@ -98,14 +100,14 @@ def train():
                     input_embeddings = input_embeddings + codec_i_embedding
 
                 outputs = model.talker(
-                    inputs_embeds=input_embeddings[:, :-1, :],
-                    attention_mask=attention_mask[:, :-1],
-                    labels=codec_0_labels[:, 1:],
+                    inputs_embeds=input_embeddings,
+                    attention_mask=attention_mask,
+                    labels=codec_0_labels,
                     output_hidden_states=True
                 )
 
-                hidden_states = outputs.hidden_states[0][-1]
-                talker_hidden_states = hidden_states[codec_mask[:, :-1]]
+                hidden_states = outputs.hidden_states[0][-1][:, :-1,:] 
+                talker_hidden_states = hidden_states[codec_mask[:, 1:]]
                 talker_codec_ids = codec_ids[codec_mask]
 
                 sub_talker_logits, sub_talker_loss = model.talker.forward_sub_talker_finetune(talker_codec_ids, talker_hidden_states)

--- a/qwen_tts/core/models/modeling_qwen3_tts.py
+++ b/qwen_tts/core/models/modeling_qwen3_tts.py
@@ -1239,7 +1239,7 @@ class Qwen3TTSTalkerCodePredictorModelForConditionalGeneration(Qwen3TTSPreTraine
 
         loss = None
         if labels is not None:
-            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+            loss = self.loss_function(logits=logits, labels=None, shift_labels=labels.contiguous(), vocab_size=self.config.vocab_size, **kwargs)
 
         return Qwen3TTSTalkerCodePredictorOutputWithPast(
             loss=loss,


### PR DESCRIPTION


**Fix label alignment bug in finetuning**

Fixes label alignment issues in `sft_12hz.py` and `modeling_qwen3_tts.py` caused by incorrect interaction with `ForCausalLMLoss` from `transformers`.

**Context**

`ForCausalLMLoss` has two modes: passing `labels` automatically shifts them left by one (token *n* predicts *n+1*), while passing `shift_labels` uses them as-is.

**`sft_12hz.py`**

The old code manually shifted inputs and labels before passing to the talker (`inputs_embeds[:, :-1]`, `labels[:, 1:]`). This is unnecessary — `ForCausalLMLoss` already handles the left-shift internally. The fix passes full unshifted tensors and adjusts hidden state slicing accordingly. Also adds the missing `text_projection` call on text embeddings.

**`modeling_qwen3_tts.py`**

The subtalker outputs 15 codes per position. Passing them via `labels` causes `ForCausalLMLoss` to shift and drop one, leaving only 14 — misaligning with the 15 logit outputs. The fix passes subtalker labels via `shift_labels` instead, bypassing the automatic shift.

---
ForCausalLMLoss implementation:

```python
def ForCausalLMLoss(
    logits, labels, vocab_size,
    num_items_in_batch=None, ignore_index=-100,
    shift_labels=None, **kwargs,
) -> torch.Tensor:
    logits = logits.float()
    if shift_labels is None:
        # Shift so that tokens < n predict n
        labels = nn.functional.pad(labels, (0, 1), value=ignore_index)
        shift_labels = labels[..., 1:].contiguous()
    logits = logits.view(-1, vocab_size)
    shift_labels = shift_labels.view(-1)
    shift_labels = shift_labels.to(logits.device)
    loss = fixed_cross_entropy(logits, shift_labels, num_items_in_batch, ignore_index, **kwargs)
    return loss
```