### PR TITLE
Pre-wire instruct support in generate_voice_clone for upcoming 25Hz model

### DIFF
--- a/qwen_tts/inference/qwen3_tts_model.py
+++ b/qwen_tts/inference/qwen3_tts_model.py
@@ -475,6 +475,7 @@ class Qwen3TTSModel:
         ref_text: Optional[Union[str, List[Optional[str]]]] = None,
         x_vector_only_mode: Union[bool, List[bool]] = False,
         voice_clone_prompt: Optional[Union[Dict[str, Any], List[VoiceClonePromptItem]]] = None,
+        instruct: Optional[Union[str, List[str]]] = None,
         non_streaming_mode: bool = False,
         **kwargs,
     ) -> Tuple[List[np.ndarray], int]:
@@ -510,6 +511,10 @@ class Qwen3TTSModel:
                 If False, ICL mode is used automatically.
             voice_clone_prompt:
                 list[VoiceClonePromptItem] from `create_voice_clone_prompt`.
+            instruct:
+                Optional instruction(s) describing desired speaking style.
+                Note: the 12Hz base model was not trained for instruct-guided voice cloning;
+                results may be unstable. Full support is planned for the upcoming 25Hz voice editing model.
             non_streaming_mode:
                 Using non-streaming text input, this option currently only simulates streaming text input when set to `false`, 
                 rather than enabling true streaming input or streaming generation.
@@ -598,10 +603,22 @@ class Qwen3TTSModel:
                     ref_tok = self._tokenize_texts([self._build_ref_text(rt)])[0]
                     ref_ids.append(ref_tok)
 
+        instructs = self._ensure_list(instruct) if instruct is not None else [""] * len(texts)
+        if len(instructs) == 1 and len(texts) > 1:
+            instructs = instructs * len(texts)
+
+        instruct_ids: List[Optional[torch.Tensor]] = []
+        for ins in instructs:
+            if ins is None or ins == "":
+                instruct_ids.append(None)
+            else:
+                instruct_ids.append(self._tokenize_texts([self._build_instruct_text(ins)])[0])
+
         gen_kwargs = self._merge_generate_kwargs(**kwargs)
 
         talker_codes_list, _ = self.model.generate(
             input_ids=input_ids,
+            instruct_ids=instruct_ids,
             ref_ids=ref_ids,
             voice_clone_prompt=voice_clone_prompt_dict,
             languages=languages,


### PR DESCRIPTION
## Summary

- Added optional `instruct` parameter to `generate_voice_clone`, allowing users to pass natural-language style instructions alongside voice cloning.
- Follows the same `instruct_ids` pattern already used in `generate_voice_design` and `generate_custom_voice`.
- Fully backwards compatible, no changes required for existing callers.

## Note

> ⚠️ This feature is experimental and may produce unstable results.
> The 12Hz base model was not trained for instruct-guided voice cloning. As noted in the README, instruction control in the base model is currently unstable. Full support for combined cloning + instruction is planned for the upcoming 25Hz voice editing model.
> Use at your own discretion and treat outputs as experimental.

It's a very important feature for us. Thanks @wangxiongts and your team for your great work. Feel free to drop any feedback/comments if needed.