### PR TITLE
fix: Set dtype on nested model config to avoid flash attention warning

### DIFF
--- a/qwen_tts/core/models/modeling_qwen3_tts.py
+++ b/qwen_tts/core/models/modeling_qwen3_tts.py
@@ -1817,6 +1817,10 @@ class Qwen3TTSForConditionalGeneration(Qwen3TTSPreTrainedModel, GenerationMixin)
         super().__init__(config)
         self.config = config
 
+        effective_dtype = getattr(self.config.talker_config, "dtype", None) or getattr(self.config, "dtype", None)
+        if effective_dtype is not None:
+            self.config.talker_config.code_predictor_config.dtype = effective_dtype
+
         self.talker = Qwen3TTSTalkerForConditionalGeneration(self.config.talker_config)
 
         if config.tts_model_type == "base":


### PR DESCRIPTION
Propagate dtype to the nested code predictor config. This avoids the warning: "You are attempting to use Flash Attention 2 without specifying a torch dtype. This might lead to unexpected behaviour"

Related Issue: #136 