### PR TITLE
fix: Parameters are updated before gradient accumulation is complete

### DIFF
--- a/finetuning/sft_12hz.py
+++ b/finetuning/sft_12hz.py
@@ -117,8 +117,8 @@ def train():
                 if accelerator.sync_gradients:
                     accelerator.clip_grad_norm_(model.parameters(), 1.0)
 
-                optimizer.step()
-                optimizer.zero_grad()
+                    optimizer.step()
+                    optimizer.zero_grad()
 
             if step % 10 == 0:
                 accelerator.print(f"Epoch {epoch} | Step {step} | Loss: {loss.item():.4f}")


### PR DESCRIPTION
When gradient accumulation is enabled, `accelerator.sync_gradients` remains `False` during intermediate accumulation steps and becomes `True` only when the accumulated gradients are ready for synchronization and an optimizer update.

In the original implementation, `optimizer.step()` and `optimizer.zero_grad()` are executed for every micro-batch regardless of the value of `sync_gradients`. As a result:

* Parameters are updated before gradient accumulation is complete.
* Accumulated gradients are cleared prematurely.
* The effective training behavior differs from the intended gradient accumulation strategy.
* Model training can become unstable and may produce a poorly trained checkpoint.

By moving `optimizer.step()` and `optimizer.zero_grad()` inside the `if accelerator.sync_gradients:` block, optimizer updates occur only at the correct accumulation boundary. This matches the intended training pattern of Hugging Face Accelerate and ensures that gradient accumulation functions properly.