### PR TITLE
fix(ci): pin github-translate-action to a version tag

### DIFF
--- a/.github/workflows/translate.yaml
+++ b/.github/workflows/translate.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: lizheming/github-translate-action
+      - uses: lizheming/github-translate-action@1.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- `.github/workflows/translate.yaml` uses `lizheming/github-translate-action` **without an `@ref`**, so GitHub Actions resolves an unpinned mutable default instead of a fixed release.
- Pin it to the latest release tag **`1.1.2`** (`c55aac477e98562d4faed9f77c54ab8306ae6ebf`).

### Current (unpinned)
```yaml
- uses: lizheming/github-translate-action
```

### Why this is a problem
Without `@<tag|sha>`, the workflow does not pin a specific action version. Supply-chain changes on the action’s default branch can change CI behavior without a corresponding change in this repository.

### Correct pin
```yaml
- uses: lizheming/github-translate-action@1.1.2
```

## Test plan
- [ ] Confirm the workflow file parses / is valid YAML
- [ ] Optionally re-run or dry-check the `translator` workflow on a test issue/discussion if maintainers want runtime confirmation


Made with [Cursor](https://cursor.com)