### PR TITLE
fix(modeling): cast logits to float32 to prevent FP16 sampling overflow

### DIFF
--- a/qwen_tts/core/models/modeling_qwen3_tts.py
+++ b/qwen_tts/core/models/modeling_qwen3_tts.py
@@ -1296,7 +1296,7 @@ class Qwen3TTSTalkerCodePredictorModelForConditionalGeneration(Qwen3TTSPreTraine
         )
 
         hidden_states = outputs.last_hidden_state
-        logits = self.lm_head[generation_steps](hidden_states)
+        logits = self.lm_head[generation_steps](hidden_states).float()
 
         loss = None
         if labels is not None:
@@ -1724,7 +1724,7 @@ class Qwen3TTSTalkerForConditionalGeneration(Qwen3TTSTalkerTextPreTrainedModel, 
         )
 
         hidden_states = outputs.last_hidden_state
-        logits = self.codec_head(hidden_states)
+        logits = self.codec_head(hidden_states).float()
 
         loss = None
         if labels is not None:


### PR DESCRIPTION
## Summary

This PR casts the output logits of `Qwen3TTSTalkerCodePredictorModelForConditionalGeneration` and `Qwen3TTSTalkerForConditionalGeneration` to `float32` prior to returning them for generation sampling. 

This resolves an unrecoverable CUDA assertion failure (`RuntimeError: CUDA error: device-side assert triggered`) when running inference in FP16 precision (`--dtype float16`).

---

## Root Cause

When running autoregressive generation with half precision (`float16`), logit values produced during forward passes can exceed the `float16` maximum dynamic range limit (~65,504). During downstream sampling steps (such as temperature scaling and Softmax in `transformers.generation.utils._sample`), these overflowing logits yield `+inf` and `NaN` probability values, triggering the PyTorch kernel failure:

```text
../aten/src/ATen/native/cuda/TensorCompare.cu:110: _assert_async_cuda_kernel: 
Assertion `probability tensor contains either `inf`, `nan` or element < 0` failed.
RuntimeError: CUDA error: device-side assert triggered
