### PR TITLE
fix: lazily import onnxruntime for the 25Hz tokenizer

### DIFF
--- a/qwen_tts/core/tokenizer_25hz/vq/speech_vq.py
+++ b/qwen_tts/core/tokenizer_25hz/vq/speech_vq.py
@@ -17,7 +17,6 @@ import sox
 import copy
 import torch
 import operator
-import onnxruntime
 
 import torch.nn as nn
 import torch.nn.functional as F
@@ -117,6 +116,10 @@ class MelSpectrogramFeatures(nn.Module):
 
 class XVectorExtractor(nn.Module):
     def __init__(self, audio_codec_with_xvector):
+        # ONNX Runtime is only needed when the 25 Hz tokenizer initializes
+        # its CAMPPlus x-vector extractor.
+        import onnxruntime
+
         super().__init__()
         option = onnxruntime.SessionOptions()
         option.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL

--- a/tests/test_lazy_onnxruntime.py
+++ b/tests/test_lazy_onnxruntime.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class LazyOnnxRuntimeTest(unittest.TestCase):
+    def _run_python(self, code):
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.pathsep.join(
+            [str(REPO_ROOT), env.get("PYTHONPATH", "")]
+        )
+        subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(code)],
+            check=True,
+            cwd=REPO_ROOT,
+            env=env,
+        )
+
+    def test_12hz_import_does_not_load_onnxruntime(self):
+        self._run_python(
+            """
+            import sys
+
+            from qwen_tts import Qwen3TTSTokenizer
+            from qwen_tts.core.tokenizer_12hz.modeling_qwen3_tts_tokenizer_v2 import (
+                Qwen3TTSTokenizerV2Model,
+            )
+
+            assert Qwen3TTSTokenizer.__name__ == "Qwen3TTSTokenizer"
+            assert Qwen3TTSTokenizerV2Model.__name__ == "Qwen3TTSTokenizerV2Model"
+            assert "onnxruntime" not in sys.modules
+            """
+        )
+
+    def test_25hz_xvector_extractor_loads_onnxruntime_on_demand(self):
+        self._run_python(
+            """
+            import sys
+            import types
+
+            from qwen_tts.core.tokenizer_25hz.vq import speech_vq
+
+            assert "onnxruntime" not in sys.modules
+            calls = []
+
+
+            class SessionOptions:
+                pass
+
+
+            class GraphOptimizationLevel:
+                ORT_ENABLE_ALL = object()
+
+
+            class Transformer:
+                def norm(self, **kwargs):
+                    calls.append(("norm", kwargs))
+
+
+            fake_ort = types.ModuleType("onnxruntime")
+            fake_ort.SessionOptions = SessionOptions
+            fake_ort.GraphOptimizationLevel = GraphOptimizationLevel
+
+
+            def inference_session(path, *, sess_options, providers):
+                calls.append(("session", path, sess_options, providers))
+                return object()
+
+
+            fake_ort.InferenceSession = inference_session
+            sys.modules["onnxruntime"] = fake_ort
+            speech_vq.sox.Transformer = Transformer
+
+            extractor = speech_vq.XVectorExtractor("campplus.onnx")
+            assert extractor.ort_session is not None
+            assert calls[0][0] == "session"
+            assert calls[0][1] == "campplus.onnx"
+            assert calls[0][3] == ["CPUExecutionProvider"]
+            assert calls[1] == ("norm", {"db_level": -6})
+            """
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Move the `onnxruntime` import from module scope into `XVectorExtractor.__init__`.
- Preserve TokenizerV1/25Hz support and the existing ONNX Runtime dependency.
- Add regression coverage for both the 12Hz import path and the 25Hz on-demand path.

## Problem

`qwen_tts` imports both tokenizer implementations. Consequently, importing Qwen3-TTS for a released 12Hz model also imports `tokenizer_25hz/vq/speech_vq.py` and loads the ONNX Runtime native library, even though the 12Hz tokenizer never uses it.

On an affected Ray/SGLang worker, the following initialization order reproduced the failure:

```python
import faulthandler
import sys

import qwen_tts
assert "onnxruntime" in sys.modules  # before this change
faulthandler.enable()
```

The last call raised:

```text
OSError: [Errno 12] Cannot allocate memory
```

Ray workers hit the same error in `ray._private.worker.connect()` at `faulthandler.enable(all_threads=False)`, then failed to register with the raylet. This later surfaced as secondary Ray connection/worker errors.

Observed environment:

- Python 3.12.3
- qwen-tts 0.1.1
- onnxruntime 1.28.0
- Ray 2.55.1 / SGLang 0.5.16
- Intel Xeon Platinum 8480+ (Sapphire Rapids with AMX enabled)
- Linux 5.10 vendor kernel

This change is intentionally not gated on a Linux kernel version. Whether the native initialization conflict is observable depends on CPU features, Python and ONNX Runtime builds, and initialization order; `< 5.14` is therefore not a reliable applicability boundary. Avoiding an unused native import benefits every 12Hz import path.

The underlying alternate-signal-stack/AMX class of issue is discussed in [python/cpython#91124](https://github.com/python/cpython/issues/91124) and [python/cpython#31789](https://github.com/python/cpython/pull/31789). This PR does not claim to fix that platform-level issue; it prevents the 12Hz path from loading a native runtime it does not need.

Unlike #109, this keeps TokenizerV1/25Hz available. When `XVectorExtractor` is actually initialized, it imports and uses ONNX Runtime exactly as before.

## Validation

```text
python tests/test_lazy_onnxruntime.py -v
Ran 2 tests in 12.751s
OK
```

The tests verify that:

1. Importing `Qwen3TTSTokenizer` and `Qwen3TTSTokenizerV2Model` does not load `onnxruntime`.
2. Initializing the 25Hz `XVectorExtractor` loads ONNX Runtime on demand and creates the CPU inference session.

Additional validation on the affected host:

- `import qwen_tts; faulthandler.enable()` succeeds with ONNX Runtime still unloaded.
- A Qwen3-TTS-12Hz-1.7B-CustomVoice OmniFlow/Ray/SGLang smoke benchmark completed 1/1 request successfully.
