### PR TITLE
Support Transformers 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,9 @@ name = "qwen-tts"
 version = "0.1.1"
 description = "Qwen-TTS python package"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -20,7 +19,7 @@ license = { text = "Apache-2.0" }
 authors = [{ name = "Alibaba Qwen Team" }]
 
 dependencies = [
-  "transformers==4.57.3",
+  "transformers>=5.15.1,<6",
   "accelerate==1.12.0",
   "gradio",
   "librosa",

--- a/qwen_tts/__init__.py
+++ b/qwen_tts/__init__.py
@@ -18,6 +18,10 @@
 qwen_tts: Qwen-TTS package.
 """
 
+from ._transformers_compat import patch_transformers_rope_registry
+
+patch_transformers_rope_registry()
+
 from .inference.qwen3_tts_model import Qwen3TTSModel, VoiceClonePromptItem
 from .inference.qwen3_tts_tokenizer import Qwen3TTSTokenizer
 

--- a/qwen_tts/_transformers_compat.py
+++ b/qwen_tts/_transformers_compat.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+# Copyright 2026 The Alibaba Qwen team.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compatibility helpers for Qwen3-TTS on Transformers 5.x."""
+
+from __future__ import annotations
+
+import torch
+
+
+_PATCHED = False
+
+
+def _default_rope_parameters(config, device=None, seq_len=None, layer_type=None):
+    """Initialize the unscaled RoPE variant removed from the 5.x registry."""
+    del seq_len, layer_type
+    base = config.rope_theta
+    partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
+    head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+    dim = int(head_dim * partial_rotary_factor)
+    inv_freq = 1.0 / (
+        base
+        ** (
+            torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float)
+            / dim
+        )
+    )
+    return inv_freq, 1.0
+
+
+def patch_transformers_rope_registry() -> None:
+    """Register the default RoPE initializer expected by Qwen3-TTS configs."""
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+    ROPE_INIT_FUNCTIONS.setdefault("default", _default_rope_parameters)
+    _PATCHED = True
+
+
+@torch.no_grad()
+def restore_rope_buffers(model) -> None:
+    """Rebuild non-persistent RoPE buffers after low-memory model loading."""
+    for module in model.modules():
+        if not all(hasattr(module, name) for name in ("rope_init_fn", "config", "inv_freq")):
+            continue
+        inv_freq, attention_scaling = module.rope_init_fn(module.config, module.inv_freq.device)
+        module.register_buffer("inv_freq", inv_freq, persistent=False)
+        module.original_inv_freq = module.inv_freq
+        module.attention_scaling = attention_scaling
+
+
+def restore_mimi_full_attention(model) -> None:
+    """Preserve the full causal Mimi attention used by Transformers 4.57.3."""
+    for module in model.modules():
+        if not module.__class__.__module__.startswith("transformers.models.mimi"):
+            continue
+        config = getattr(module, "config", None)
+        if config is None or not hasattr(config, "sliding_window"):
+            continue
+        full_window = config.max_position_embeddings
+        config.sliding_window = full_window
+        if hasattr(module, "sliding_window"):
+            module.sliding_window = full_window

--- a/qwen_tts/core/models/configuration_qwen3_tts.py
+++ b/qwen_tts/core/models/configuration_qwen3_tts.py
@@ -12,8 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from transformers.configuration_utils import PretrainedConfig, layer_type_validation
-from transformers.modeling_rope_utils import rope_config_validation
+from transformers.configuration_utils import PretrainedConfig
 from transformers.utils import logging
 
 logger = logging.get_logger(__name__)
@@ -166,6 +165,9 @@ class Qwen3TTSTalkerCodePredictorConfig(PretrainedConfig):
     """
 
     model_type = "qwen3_tts_talker_code_predictor"
+    pad_token_id = None
+    bos_token_id = None
+    eos_token_id = None
     keys_to_ignore_at_inference = ["past_key_values"]
 
     # Default tensor parallel plan for base model `Qwen3TTSTalkerCodePredictor`
@@ -242,7 +244,8 @@ class Qwen3TTSTalkerCodePredictorConfig(PretrainedConfig):
         # BC: if there is a 'type' field, move it to 'rope_type'.
         if self.rope_scaling is not None and "type" in self.rope_scaling:
             self.rope_scaling["rope_type"] = self.rope_scaling["type"]
-        rope_config_validation(self)
+        self.standardize_rope_params()
+        self.validate_rope()
 
         self.layer_types = layer_types
         if self.layer_types is None:
@@ -252,7 +255,7 @@ class Qwen3TTSTalkerCodePredictorConfig(PretrainedConfig):
                 else "full_attention"
                 for i in range(self.num_hidden_layers)
             ]
-        layer_type_validation(self.layer_types)
+        self.validate_layer_type()
         self.num_code_groups = num_code_groups
 
 
@@ -348,6 +351,9 @@ class Qwen3TTSTalkerConfig(PretrainedConfig):
     """
 
     model_type = "qwen3_tts_talker"
+    pad_token_id = None
+    bos_token_id = None
+    eos_token_id = None
     keys_to_ignore_at_inference = ["past_key_values"]
 
     # Default tensor parallel plan for base model `Qwen3TTSTalker`

--- a/qwen_tts/core/models/modeling_qwen3_tts.py
+++ b/qwen_tts/core/models/modeling_qwen3_tts.py
@@ -1093,15 +1093,13 @@ class Qwen3TTSTalkerCodePredictorModel(Qwen3TTSPreTrainedModel):
 
         # It may already have been prepared by e.g. `generate`
         if not isinstance(causal_mask_mapping := attention_mask, dict):
-            # Prepare mask arguments
             mask_kwargs = {
                 "config": self.config,
-                "input_embeds": inputs_embeds,
+                "inputs_embeds": inputs_embeds,
                 "attention_mask": attention_mask,
-                "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
-            # Create the masks
             causal_mask_mapping = {
                 "full_attention": create_causal_mask(**mask_kwargs),
             }
@@ -1510,9 +1508,8 @@ class Qwen3TTSTalkerModel(Qwen3TTSTalkerTextPreTrainedModel):
         mask_function = create_causal_mask if self.config.sliding_window is None else create_sliding_window_causal_mask
         causal_mask = mask_function(
             config=self.config,
-            input_embeds=inputs_embeds,
+            inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
-            cache_position=cache_position,
             past_key_values=past_key_values,
             position_ids=text_position_ids,
         )
@@ -1661,6 +1658,15 @@ class Qwen3TTSTalkerForConditionalGeneration(Qwen3TTSTalkerTextPreTrainedModel, 
             config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
             (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
         ```"""
+        if cache_position is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            sequence_length = inputs_embeds.shape[1] if inputs_embeds is not None else input_ids.shape[1]
+            cache_position = torch.arange(
+                past_seen_tokens,
+                past_seen_tokens + sequence_length,
+                device=(inputs_embeds if inputs_embeds is not None else input_ids).device,
+            )
+
         # Prefill
         if inputs_embeds is not None and inputs_embeds.shape[1] > 1:
             generation_step = -1
@@ -1888,6 +1894,9 @@ class Qwen3TTSForConditionalGeneration(Qwen3TTSPreTrainedModel, GenerationMixin)
             attn_implementation=requested_attn_implementation,
             **kwargs,
         )
+        from ..._transformers_compat import restore_rope_buffers
+
+        restore_rope_buffers(model)
         if not local_files_only and not os.path.isdir(pretrained_model_name_or_path):
             download_cache_dir = kwargs.get("cache_dir", cache_dir)
             download_revision = kwargs.get("revision", revision)

--- a/qwen_tts/core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
+++ b/qwen_tts/core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py
@@ -39,7 +39,6 @@ from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from transformers.processing_utils import Unpack
 from transformers.utils import ModelOutput, auto_docstring, logging
 from transformers.utils.deprecation import deprecate_kwarg
-from transformers.utils.generic import check_model_inputs
 
 from .configuration_qwen3_tts_tokenizer_v2 import (
     Qwen3TTSTokenizerV2Config,
@@ -496,8 +495,6 @@ class Qwen3TTSTokenizerV2DecoderTransformerModel(Qwen3TTSTokenizerV2DecoderPreTr
         # Initialize weights and apply final processing
         self.post_init()
 
-    @check_model_inputs()
-    @auto_docstring
     def forward(
         self,
         input_ids=None,
@@ -536,9 +533,8 @@ class Qwen3TTSTokenizerV2DecoderTransformerModel(Qwen3TTSTokenizerV2DecoderPreTr
             # Prepare mask arguments
             mask_kwargs = {
                 "config": self.config,
-                "input_embeds": inputs_embeds,
+                "inputs_embeds": inputs_embeds,
                 "attention_mask": attention_mask,
-                "cache_position": cache_position,
                 "past_key_values": past_key_values,
                 "position_ids": position_ids,
             }

--- a/qwen_tts/inference/qwen3_tts_tokenizer.py
+++ b/qwen_tts/inference/qwen3_tts_tokenizer.py
@@ -86,6 +86,10 @@ class Qwen3TTSTokenizer:
 
         inst.feature_extractor = AutoFeatureExtractor.from_pretrained(pretrained_model_name_or_path)
         inst.model = AutoModel.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        from .._transformers_compat import restore_mimi_full_attention, restore_rope_buffers
+
+        restore_rope_buffers(inst.model)
+        restore_mimi_full_attention(inst.model)
         inst.config = inst.model.config
 
         inst.device = getattr(inst.model, "device", None)

--- a/tests/test_transformers_compat.py
+++ b/tests/test_transformers_compat.py
@@ -1,0 +1,56 @@
+import torch
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+from qwen_tts._transformers_compat import (
+    patch_transformers_rope_registry,
+    restore_mimi_full_attention,
+    restore_rope_buffers,
+)
+
+
+class _RopeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = object()
+        self.register_buffer("inv_freq", torch.zeros(2), persistent=False)
+        self.original_inv_freq = self.inv_freq
+        self.attention_scaling = 0.0
+
+    @staticmethod
+    def rope_init_fn(config, device):
+        del config
+        return torch.tensor([1.0, 0.5], device=device), 1.0
+
+
+class _MimiModule(torch.nn.Module):
+    __module__ = "transformers.models.mimi.modeling_mimi"
+
+    def __init__(self):
+        super().__init__()
+        self.config = type("Config", (), {"max_position_embeddings": 8000, "sliding_window": 250})()
+        self.sliding_window = 250
+
+
+def test_restore_rope_buffers():
+    model = torch.nn.Sequential(_RopeModule())
+
+    restore_rope_buffers(model)
+
+    torch.testing.assert_close(model[0].inv_freq, torch.tensor([1.0, 0.5]))
+    assert model[0].original_inv_freq is model[0].inv_freq
+    assert model[0].attention_scaling == 1.0
+
+
+def test_default_rope_initializer_is_registered():
+    patch_transformers_rope_registry()
+
+    assert "default" in ROPE_INIT_FUNCTIONS
+
+
+def test_restore_mimi_full_attention():
+    model = torch.nn.Sequential(_MimiModule())
+
+    restore_mimi_full_attention(model)
+
+    assert model[0].config.sliding_window == 8000
+    assert model[0].sliding_window == 8000


### PR DESCRIPTION
## Summary

- replace the exact Transformers 4.57.3 pin with `transformers>=5.15.1,<6`
- update the minimum Python version to 3.10, matching Transformers 5
- adapt causal-mask, generation-cache, configuration, and tokenizer APIs for Transformers 5
- restore non-persistent RoPE buffers after low-memory loading
- preserve the full-attention Mimi behavior used by Transformers 4.57.3
- add focused regression tests for the compatibility helpers

Closes #237.

## Why the behavioral compatibility is needed

The initial API changes are straightforward, but testing uncovered two silent behavioral regressions:

1. Transformers 5 no longer includes the `default` RoPE initializer in `ROPE_INIT_FUNCTIONS`, and low-memory loading can leave Qwen's non-persistent `inv_freq` buffers materialized as zeros. Generation then agrees at position zero but diverges at later positions and may never reach EOS.
2. Transformers 5's Mimi implementation uses sliding-window causal attention. Qwen3-TTS previously used full causal attention through Transformers 4.57.3, so the new behavior changes reference codec tokens and breaks ICL text/audio alignment.

The compatibility helpers explicitly rebuild RoPE buffers after loading and set Mimi's window to its full supported context, retaining the behavior of the currently pinned release.

## Validation

Tested on an NVIDIA GB10 DGX Spark with Transformers 5.15.1 and PyTorch 2.11.0+cu130:

- `3 passed` focused compatibility tests
- package wheel builds with the expected `transformers>=5.15.1,<6` metadata
- public `Qwen3TTSModel.generate_voice_clone` x-vector generation succeeds in BF16 with finite, non-silent audio
- ICL codec conditioning matches the Transformers 4.57.3 baseline
- downstream faster-qwen3-tts suite: `78 passed, 1 skipped`, including BF16 natural-EOS, FP32 exact-token parity, ICL parity, and CUDA graph tests
- downstream DGX benchmark shows no throughput regression: TTFA improves 2.3–3.9%, buffered throughput 2.2%, and streaming throughput 3.1%

Downstream integration: https://github.com/andimarafioti/faster-qwen3-tts/pull/135
